### PR TITLE
chore(apps/persona): reduce padding for Traits section

### DIFF
--- a/apps/persona/src/lib/components/Traits.svelte
+++ b/apps/persona/src/lib/components/Traits.svelte
@@ -271,7 +271,7 @@
 <section
   id="traits"
   aria-labelledby="traits-title"
-  class="scroll-mt-14 py-16 sm:scroll-mt-32 sm:py-20 lg:py-32"
+  class="scroll-mt-14 pt-16 sm:scroll-mt-32 sm:pt-20 lg:pt-32"
 >
   <Container class="space-y-6">
     <SectionHeading number="1" id="traits-title">Traits</SectionHeading>


### PR DESCRIPTION
This PR aims to reduce the gap between the Traits and Comparison section by reducing the padding for Traits for all viewports. This change introduces much needed visual consistency across the website.