### PR TITLE
feat(apps/chat): Changed user inputs to plaintext-only to prevent formatting issues on paste

### DIFF
--- a/apps/chat/src/routes/(app)/+page.svelte
+++ b/apps/chat/src/routes/(app)/+page.svelte
@@ -98,7 +98,7 @@
         class:min-h-24={expanded}
         class:px-6={expanded}
         class:pt-4={expanded}
-        contenteditable
+        contenteditable="plaintext-only"
         bind:textContent={prompt}
         bind:this={input}
         onkeydown={enter}

--- a/apps/chat/src/routes/(app)/new/+page.svelte
+++ b/apps/chat/src/routes/(app)/new/+page.svelte
@@ -209,7 +209,7 @@
     >
       <p
         class="text-text-400 relative block max-h-32 min-h-16 max-w-full overflow-hidden overflow-y-auto px-6 py-4 break-words focus:outline-hidden"
-        contenteditable
+        contenteditable="plaintext-only"
         bind:textContent={prompt}
         onkeydown={enter}
       ></p>


### PR DESCRIPTION
Follows wider browser support, see https://caniuse.com/mdn-api_htmlelement_contenteditable_plaintext-only